### PR TITLE
Changed wrapper height.

### DIFF
--- a/jquery.flip.js
+++ b/jquery.flip.js
@@ -55,7 +55,7 @@
           perspective: prespective,
           position: "relative",
           width: $dom.width(),
-          height: $dom.height(),
+          height: Math.max($dom.find(".front").height(), $dom.find(".back").height()),
           margin: $dom.css('margin')
         });
 


### PR DESCRIPTION
The .flip element height is set to match the height of the tallest of the .front and .back elements instead of the height of both elements.
