### PR TITLE
Fixed transition property being lost on Edge, IE11, ..

### DIFF
--- a/src/flip.js
+++ b/src/flip.js
@@ -236,7 +236,7 @@
     }
     if (changeNeeded){
       var faces = $(this).find($(this).data("front")).add($(this).data("back"), $(this));
-      var savedTrans = faces.css("transition");
+      var savedTrans = faces.css(["transition-property", "transition-timing-function", "transition-duration", "transition-delay"]);
       faces.css({
         transition: "none"
       });
@@ -260,9 +260,7 @@
       }
       //Providing a nicely wrapped up callback because transform is essentially async
       setTimeout(function(){
-        faces.css({
-          transition: savedTrans
-        });
+        faces.css(savedTrans);
           callback.call(this);
       }.bind(this),0);
     }else{


### PR DESCRIPTION
There was an issue where the transition property would be lost while dynamically changing any property in Edge and IE11 due to what's described in https://github.com/jquery/jquery/issues/2535. As suggested i've fixed this by getting each property individually instead of the shorthand.

It seems like there may possibly be another change coming as a result of #39, so i'll wait until that's resolved until we merge this.