### PR TITLE
Adding main to package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "keywords": [
     "jquery-plugin"
   ],
+  "main": "dist/jquery.flip.js",
   "homepage": "https://github.com/nnattawat/flip",
   "bugs": "https://github.com/nnattawat/flip/issues",
   "author": {


### PR DESCRIPTION
I added a `main` key to `package.json` so that we could use the library with NPM. Feel free to merge it in if that seems useful.